### PR TITLE
feat: Integrate OpenFeign client for service-to-service communication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<spring-cloud.version>2025.0.0</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -50,12 +51,27 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-openfeign</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/java/com/quiz/Controller/QuizController.java
+++ b/src/main/java/com/quiz/Controller/QuizController.java
@@ -1,24 +1,32 @@
 package com.quiz.Controller;
 
 import com.quiz.Entity.Quiz;
+import com.quiz.Service.QuestionClient;
 import com.quiz.ServiceImpl.QuizServiceImpl;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/quiz")
 public class QuizController {
 
     private final QuizServiceImpl quizService;
+    private final QuestionClient questionClient;
 
-    public QuizController(QuizServiceImpl quizService) {
+    public QuizController(QuizServiceImpl quizService,QuestionClient questionClient) {
         this.quizService = quizService;
+        this.questionClient = questionClient;
     }
 
     @GetMapping
     List<Quiz> getAllQuiz(){
-        return quizService.getAllQuiz();
+        List<Quiz> quizes = quizService.getAllQuiz();
+        return quizes.stream().map(quiz ->{
+            quiz.setQuestion(questionClient.getQuestionByQuizId(quiz.getId()));
+            return quiz;
+        }).collect(Collectors.toList());
     }
 
     @GetMapping("/{qId}")

--- a/src/main/java/com/quiz/Entity/Question.java
+++ b/src/main/java/com/quiz/Entity/Question.java
@@ -1,0 +1,40 @@
+package com.quiz.Entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Question {
+    private Integer questionId;
+    private String question;
+    private Integer quizId;
+
+    public void setQuestionId(Integer questionId) {
+        this.questionId = questionId;
+    }
+
+    public void setQuestion(String question) {
+        this.question = question;
+    }
+
+    public void setQuizId(Integer quizId) {
+        this.quizId = quizId;
+    }
+
+    public Integer getQuestionId() {
+        return questionId;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public Integer getQuizId() {
+        return quizId;
+    }
+}

--- a/src/main/java/com/quiz/Entity/Quiz.java
+++ b/src/main/java/com/quiz/Entity/Quiz.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -19,4 +21,31 @@ public class Quiz {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
     private String quiz;
+    // TRANSIENT: to prevent the record being saved in DB when POST API is called to save the Quiz
+    transient private List<Question> question; 
+
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getQuiz() {
+        return quiz;
+    }
+
+    public void setQuiz(String quiz) {
+        this.quiz = quiz;
+    }
+
+    public List<Question> getQuestion() {
+        return question;
+    }
+
+    public void setQuestion(List<Question> question) {
+        this.question = question;
+    }
 }

--- a/src/main/java/com/quiz/QuizApplication.java
+++ b/src/main/java/com/quiz/QuizApplication.java
@@ -2,8 +2,10 @@ package com.quiz;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class QuizApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/quiz/Service/QuestionClient.java
+++ b/src/main/java/com/quiz/Service/QuestionClient.java
@@ -1,0 +1,19 @@
+package com.quiz.Service;
+
+import com.quiz.Entity.Question;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@FeignClient(url = "http://localhost:8081",value = "Question-Client")
+public interface QuestionClient {
+
+    @GetMapping("/question")
+    public List<Question> getAllQuestion();
+
+    @GetMapping("/question/quiz/{quizId}")
+    public List<Question> getQuestionByQuizId(@PathVariable Integer quizId);
+
+}


### PR DESCRIPTION
feat: Integrate OpenFeign client for service-to-service communication

- Added OpenFeign dependencies in pom.xml
- **Created Feign client(QuestionClient) interfaces** for external API consumption
- Updated service layer to use Feign client for external calls through constructor injection
-  **Added Spring Cloud** and added OpenFeign Client dependency.

# Improves modularity and simplifies HTTP client logic
OpenFeign is a declarative REST client in Java used to simplify HTTP communication between microservices. Instead of writing boilerplate code with RestTemplate or WebClient, I can define an interface and annotate it with Feign annotations like @FeignClient. Spring Cloud then automatically generates the implementation at runtime. It supports features like load balancing, fallback handling, and request logging. I’ve used it in projects to make service-to-service calls cleaner, more readable, and easier to maintain.